### PR TITLE
Use historical closes when last trade endpoint is blocked

### DIFF
--- a/polygon_data.py
+++ b/polygon_data.py
@@ -222,19 +222,19 @@ def get_ticker_snapshot(
 
     sector = getattr(details, "sector", None) or "Unknown"
 
-    try:
-        last_trade = client.get_last_trade(ticker)
-        current_price = getattr(last_trade, "price", None)
-    except Exception:
-        current_price = None
-
-    if current_price is None:
-        return None
-
     hist_prices, hist_vol = get_historical_volatility(
         client, ticker, days=hv_days, window=hv_window
     )
     if hist_vol is None or not np.isfinite(hist_vol):
+        return None
+
+    current_price = None
+    if not hist_prices.empty:
+        latest_close = hist_prices["Close"].dropna()
+        if not latest_close.empty:
+            current_price = float(latest_close.iloc[-1])
+
+    if current_price is None:
         return None
 
     call_iv, put_iv, expiry = get_option_iv_snapshot(

--- a/volatility_dashboard.py
+++ b/volatility_dashboard.py
@@ -117,13 +117,41 @@ st.caption("Built with Streamlit + Polygon.io")
 
 df = fetch_stock_data()
 
+if df.empty:
+    st.error(
+        "No ticker data was retrieved from Polygon. Please verify your API key and "
+        "plan permissions, then try again."
+    )
+    st.stop()
+
+required_columns = {
+    "Ticker",
+    "Call_IV_Premium",
+    "Put_IV_Premium",
+    "IV_Skew",
+    "AvgCallIV",
+    "AvgPutIV",
+    "CurrentPrice",
+}
+
+missing_columns = sorted(required_columns.difference(df.columns))
+if missing_columns:
+    st.error(
+        "The Polygon response was missing required fields: "
+        f"{', '.join(missing_columns)}. Please try again later."
+    )
+    st.stop()
+
+if "Sector" not in df.columns:
+    df["Sector"] = "Unknown"
+
 st.sidebar.header("Filters")
 min_premium = st.sidebar.slider("Minimum IV Premium", 1.0, 3.0, 1.5, step=0.1)
 top_n = st.sidebar.slider("Top N stocks", 5, 20, 10)
 
 sector_filter = st.sidebar.multiselect(
     "Sector Filter",
-    options=["All"] + sorted(list(set(df['Sector']))),
+    options=["All"] + sorted(df["Sector"].dropna().unique().tolist()),
     default=["All"]
 )
 


### PR DESCRIPTION
## Summary
- derive the current price for each ticker from the latest historical close instead of the last trade endpoint
- keep generating option snapshots so the screener still works even when the Polygon last trade API returns 403s

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e46070af64832f8e3ceb685bba2c68